### PR TITLE
Fix string interpolation inclusion. 

### DIFF
--- a/_sources/StringFormatting/CSV.rst
+++ b/_sources/StringFormatting/CSV.rst
@@ -30,7 +30,7 @@ The typical pattern for writing data to a CSV file will be to write a header row
    outfile.write("Name, score, grade\n")
    # output each of the rows:
    for student in students:
-       outfile.write("%s, %d, %s\n" % student)
+       outfile.write("{}, {}, {}\n".format(student))
    outfile.close()
    
 There are a couple of things worth noting in the code above. First, unlike the print statement, the .write() method on a file object does not automatically insert a newline. Instead, we had to explicitly add the character ``\n`` at the end of each line.
@@ -50,7 +50,7 @@ If one or more columns contain text, and that text could contain commas, we need
    outfile.write('"Name", "score", "grade"\n')
    # output each of the rows:
    for student in students:
-       outfile.write('"%s", "%d", "%s"\n' % student)
+       outfile.write('"{}", "{}", "{}"\n'.format(student))
    outfile.close()
 
 Python also includes a .csv module, which provides a cleaner, more abstract way to handle writing .csv files. It can generate slightly different CSV formats, and handles a few other aspects of more complicated outputs in a nice way. You are welcome to explore the `documentation for the csv module <https://docs.python.org/2/library/csv.html>`_ if you'd like to learn how to use it.

--- a/_sources/StringFormatting/Exercises.rst
+++ b/_sources/StringFormatting/Exercises.rst
@@ -10,30 +10,28 @@
 Exercises
 ---------
   
-1. Fill in the variables t and v so that it it prints out: ``You have $4.99 in your pocket``
+1. Fill in the variable t so that it it prints out: ``You have $4.99 in your pocket``
 
-.. actex:: interpolation_6
-
-   pocketmoney = 4.99
-   t =
-   v =
-   newstring = t % v
-   print newstring
-   
-2. Fill in the variables t and v so that it it prints out: ``You have $5 in your pocket``
-
-.. actex:: interpolation_7
+.. activecode:: interpolation_6
 
    pocketmoney = 4.99
    t =
-   v =
-   newstring = t % v
+   newstring = t.format(pocketmoney)
    print newstring
    
-3. Fill in the missing code after the vals = on the first line, so that it prints out: ``v1, v2 are the 2 items in the list``
+   
+2. Fill in the missing code after the vals = on the first line, so that it prints out: ``v1, v2 are the 2 items in the list``
 
-.. actex:: interpolation_8
+.. activecode:: interpolation_8
 
    vals =                            
-   templ = "%s, %s are the %d items in the list"
-   print templ % (vals[0], vals[1], len(vals))
+   templ = "{}, {} are the %d items in the list"
+   print templ.format(vals[0], vals[1], len(vals))
+
+
+3. Fill in the missing code after the ``val =`` on the first line, so that it prints out: ``Hey, you, you there!``
+
+.. activecode:: interpolation_9
+
+   val = 
+   temp = "Hey, {}, {} there!".format(val)


### PR DESCRIPTION
I separated this from the larger commits so this would be an easy merge (no thoroughly new content to review), since it is fixes for the CSV writing chapter where string interpolation occurred in the examples. Now they will have the format method syntax.
