### PR TITLE
Add db_url line to stop brightly colored error on build.

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -6,6 +6,7 @@ paver.setuputils.install_distutils_tasks()
 
 ######## CHANGE THIS ##########
 project_name = "pip2"
+db_url = ""
 ###############################
 
 master_url = 'http://127.0.0.1:8000'


### PR DESCRIPTION
What do you think about this? (Just adding the one line to the new pavement.py format. It would still build via runestone build, but the "errors" that show up on build with this addition are less scary...)
