### PR TITLE
Fix ps1 point allocation for #8

### DIFF
--- a/_sources/Assignments/ps1.rst
+++ b/_sources/Assignments/ps1.rst
@@ -13,7 +13,7 @@
 .. assignment::
   :name: PS1
   :assignment_type: problem_set
-  :questions: ps_1_1 100, ps_1_2 50, ps_1_3 150, ps_1_4 100, ps_1_5 100, ps_1_6 100, ps_1_7 100, ps_1_8 150, ps_1_9 100, ps_1_10 0, ps_1_11 50
+  :questions: ps_1_1 100, ps_1_2 50, ps_1_3 150, ps_1_4 100, ps_1_5 100, ps_1_6 100, ps_1_7 150, ps_1_8 100, ps_1_9 100, ps_1_10 0, ps_1_11 50
   :deadline: 2016-09-30 04:00
   :points: 1000
   :autograde: unittest


### PR DESCRIPTION
Need to merge this to officially-release final PS1 grades
