### PR TITLE
Trying this percent for usageassignment where they only had one

### DIFF
--- a/_sources/Assignments/ps9.rst
+++ b/_sources/Assignments/ps9.rst
@@ -22,7 +22,7 @@ Activities through 11/18
   :subchapters: FacebookAPI/FBAPI
   :assignment_name: Prep 18
   :deadline: 2016-11-14 22:40
-  :pct_required: 1
+  :pct_required: 50
   :points: 50
 
 * **Before class Wednesday 11/16:**


### PR DESCRIPTION
-- one path to open b/c 1/100 does not work

I think the real solution to this is in the grading interface, but maybe this will work to generate it so that people get points? The calculated amt as a result of Calculate Totals suggests to me that it isn't measuring "did they open the page before class" properly, and I think trying this kind of % might work, where 1 did not? At any rate, this can't be worse and won't hurt anything. I can't test it properly right now and I don't have time to implement my idea just yet, so worth trying. In the meantime, Prep 18 is not released yet for 506, and if it isn't for a few days, that'll be OK, it's just the one. All the others released through Prep 19.