### PR TITLE
Resolve build error on double id in listcomp extraex.

### DIFF
--- a/_sources/AdvancedAccumulation/ExtraExercises.rst
+++ b/_sources/AdvancedAccumulation/ExtraExercises.rst
@@ -158,9 +158,9 @@ Extra Exercises
 
    myTests().main()
 
-3.1 Below, we have provided a list of integers called ``nums``. Use reduce to produce a variable, ``product``, that is all of the integers in ``nums`` multiplied together. 
+3.2 Below, we have provided a list of integers called ``nums``. Use reduce to produce a variable, ``product``, that is all of the integers in ``nums`` multiplied together. 
 
-.. activecode:: ee_listcomp_031
+.. activecode:: ee_listcomp_032
    :tags: AdvancedAccumulation/reduce.rst
 
    nums = [5, 2, 3, 4, 8, 7, 6]


### PR DESCRIPTION
This is a pull request that should go to whatever repo @soney and I should pull from for changes to the textbook / where the non-assignments textbook changes live.

It resolves an inoffensive build error (double of an active code id in extra exercises). I guess these should live in a presnick/W17 branch eventually?