### PR TITLE
Modified the exception intro to show `except Exception as e`

### DIFF
--- a/_sources/Exceptions/intro-exceptions.rst
+++ b/_sources/Exceptions/intro-exceptions.rst
@@ -104,7 +104,7 @@ There's one other useful feature. The exception code can access a variable that 
        items = ['a', 'b']
        third = items[2]
        print("This won't print")
-   except Exception, e:
+   except Exception as e:
        print("got an error")
        print(e)
    
@@ -171,7 +171,7 @@ There's one other useful feature. The exception code can access a variable that 
       try:
           for i in range(5):
               print(1.0 / (3-i))
-      except Exception, error_inst:
+      except Exception as error_inst:
           print("Got an error", error_inst)
 
 


### PR DESCRIPTION
The book is explaining to use 'except Exception, e:' but Python 3.x and modern versions of Python 2.x use 'except Exception as e' instead of 'except Exception, e'. So I modified it to the new version.